### PR TITLE
feat: Terraform AWS infrastructure (ECS Fargate + ALB + ECR)

### DIFF
--- a/terraform/aws/feature-flags.tfvars.example
+++ b/terraform/aws/feature-flags.tfvars.example
@@ -1,0 +1,7 @@
+aws_region       = "eu-central-1"
+project_name     = "storefront"
+image_tag        = "latest"
+strapi_url       = "https://your-strapi-instance.example.com"
+strapi_api_token = "your-strapi-api-token"
+n8n_webhook_url  = "https://your-n8n-instance.example.com/webhook/order-confirmed"
+site_url         = "https://your-storefront.example.com"

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+module "aws" {
+  source           = "../modules/aws"
+  aws_region       = var.aws_region
+  project_name     = var.project_name
+  image_tag        = var.image_tag
+  strapi_url       = var.strapi_url
+  strapi_api_token = var.strapi_api_token
+  n8n_webhook_url  = var.n8n_webhook_url
+  site_url         = var.site_url
+}

--- a/terraform/aws/outputs.tf
+++ b/terraform/aws/outputs.tf
@@ -1,0 +1,9 @@
+output "storefront_url" {
+  description = "ALB DNS name (public URL of the storefront)"
+  value       = "http://${module.aws.alb_dns_name}"
+}
+
+output "ecr_repository_url" {
+  description = "ECR repository URL for pushing Docker images"
+  value       = module.aws.ecr_repository_url
+}

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -1,0 +1,39 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "eu-central-1"
+}
+
+variable "project_name" {
+  description = "Project name prefix for all resources"
+  type        = string
+  default     = "storefront"
+}
+
+variable "image_tag" {
+  description = "Docker image tag to deploy"
+  type        = string
+  default     = "latest"
+}
+
+variable "strapi_url" {
+  description = "Public URL of the Strapi CMS instance"
+  type        = string
+}
+
+variable "strapi_api_token" {
+  description = "Strapi API token (sensitive)"
+  type        = string
+  sensitive   = true
+}
+
+variable "n8n_webhook_url" {
+  description = "n8n webhook URL for order notifications"
+  type        = string
+  sensitive   = true
+}
+
+variable "site_url" {
+  description = "Public URL of the storefront"
+  type        = string
+}

--- a/terraform/modules/aws/alb.tf
+++ b/terraform/modules/aws/alb.tf
@@ -1,0 +1,40 @@
+resource "aws_lb" "main" {
+  name               = "${var.project_name}-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = aws_subnet.public[*].id
+
+  tags = { Name = "${var.project_name}-alb" }
+}
+
+resource "aws_lb_target_group" "storefront" {
+  name        = "${var.project_name}-tg"
+  port        = 3000
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.main.id
+  target_type = "ip"
+
+  health_check {
+    enabled             = true
+    path                = "/api/health"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    timeout             = 5
+    interval            = 30
+    matcher             = "200"
+  }
+
+  tags = { Name = "${var.project_name}-tg" }
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.storefront.arn
+  }
+}

--- a/terraform/modules/aws/ecr.tf
+++ b/terraform/modules/aws/ecr.tf
@@ -1,0 +1,25 @@
+resource "aws_ecr_repository" "storefront" {
+  name                 = "${var.project_name}-storefront"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "storefront" {
+  repository = aws_ecr_repository.storefront.name
+
+  policy = jsonencode({
+    rules = [{
+      rulePriority = 1
+      description  = "Keep last 10 images"
+      selection = {
+        tagStatus   = "any"
+        countType   = "imageCountMoreThan"
+        countNumber = 10
+      }
+      action = { type = "expire" }
+    }]
+  })
+}

--- a/terraform/modules/aws/ecs.tf
+++ b/terraform/modules/aws/ecs.tf
@@ -1,0 +1,108 @@
+data "aws_caller_identity" "current" {}
+
+resource "aws_cloudwatch_log_group" "storefront" {
+  name              = "/ecs/${var.project_name}-storefront"
+  retention_in_days = 7
+}
+
+resource "aws_ssm_parameter" "strapi_api_token" {
+  name  = "/${var.project_name}/STRAPI_API_TOKEN"
+  type  = "SecureString"
+  value = var.strapi_api_token
+}
+
+resource "aws_ssm_parameter" "n8n_webhook_url" {
+  name  = "/${var.project_name}/N8N_WEBHOOK_URL"
+  type  = "SecureString"
+  value = var.n8n_webhook_url
+}
+
+resource "aws_iam_role" "ecs_task_execution" {
+  name = "${var.project_name}-ecs-task-execution"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution" {
+  role       = aws_iam_role.ecs_task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy" "ecs_ssm" {
+  name = "${var.project_name}-ecs-ssm"
+  role = aws_iam_role.ecs_task_execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["ssm:GetParameters", "ssm:GetParameter"]
+      Resource = "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/${var.project_name}/*"
+    }]
+  })
+}
+
+resource "aws_ecs_cluster" "main" {
+  name = "${var.project_name}-cluster"
+}
+
+resource "aws_ecs_task_definition" "storefront" {
+  family                   = "${var.project_name}-storefront"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "256"
+  memory                   = "512"
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+
+  container_definitions = jsonencode([{
+    name  = "storefront"
+    image = "${aws_ecr_repository.storefront.repository_url}:${var.image_tag}"
+    portMappings = [{ containerPort = 3000, protocol = "tcp" }]
+    environment = [
+      { name = "NEXT_PUBLIC_STRAPI_URL", value = var.strapi_url },
+      { name = "NEXT_PUBLIC_SITE_URL",   value = var.site_url },
+      { name = "NODE_ENV",               value = "production" }
+    ]
+    secrets = [
+      { name = "STRAPI_API_TOKEN", valueFrom = aws_ssm_parameter.strapi_api_token.arn },
+      { name = "N8N_WEBHOOK_URL",  valueFrom = aws_ssm_parameter.n8n_webhook_url.arn }
+    ]
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        "awslogs-group"         = aws_cloudwatch_log_group.storefront.name
+        "awslogs-region"        = var.aws_region
+        "awslogs-stream-prefix" = "ecs"
+      }
+    }
+  }])
+}
+
+resource "aws_ecs_service" "storefront" {
+  name            = "${var.project_name}-storefront"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.storefront.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = aws_subnet.public[*].id
+    security_groups  = [aws_security_group.ecs.id]
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.storefront.arn
+    container_name   = "storefront"
+    container_port   = 3000
+  }
+
+  depends_on = [aws_lb_listener.http]
+}

--- a/terraform/modules/aws/outputs.tf
+++ b/terraform/modules/aws/outputs.tf
@@ -1,0 +1,9 @@
+output "alb_dns_name" {
+  description = "ALB DNS name"
+  value       = aws_lb.main.dns_name
+}
+
+output "ecr_repository_url" {
+  description = "ECR repository URL"
+  value       = aws_ecr_repository.storefront.repository_url
+}

--- a/terraform/modules/aws/security_groups.tf
+++ b/terraform/modules/aws/security_groups.tf
@@ -1,0 +1,43 @@
+resource "aws_security_group" "alb" {
+  name        = "${var.project_name}-alb-sg"
+  description = "ALB security group"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "${var.project_name}-alb-sg" }
+}
+
+resource "aws_security_group" "ecs" {
+  name        = "${var.project_name}-ecs-sg"
+  description = "ECS tasks security group"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 3000
+    to_port         = 3000
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "${var.project_name}-ecs-sg" }
+}

--- a/terraform/modules/aws/variables.tf
+++ b/terraform/modules/aws/variables.tf
@@ -1,0 +1,36 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name prefix for all resources"
+  type        = string
+}
+
+variable "image_tag" {
+  description = "Docker image tag to deploy"
+  type        = string
+}
+
+variable "strapi_url" {
+  description = "Public URL of the Strapi CMS instance"
+  type        = string
+}
+
+variable "strapi_api_token" {
+  description = "Strapi API token (sensitive)"
+  type        = string
+  sensitive   = true
+}
+
+variable "n8n_webhook_url" {
+  description = "n8n webhook URL for order notifications"
+  type        = string
+  sensitive   = true
+}
+
+variable "site_url" {
+  description = "Public URL of the storefront"
+  type        = string
+}

--- a/terraform/modules/aws/vpc.tf
+++ b/terraform/modules/aws/vpc.tf
@@ -1,0 +1,44 @@
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = { Name = "${var.project_name}-vpc" }
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+resource "aws_subnet" "public" {
+  count             = 2
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.${count.index}.0/24"
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  map_public_ip_on_launch = true
+
+  tags = { Name = "${var.project_name}-public-${count.index}" }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = { Name = "${var.project_name}-igw" }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = { Name = "${var.project_name}-public-rt" }
+}
+
+resource "aws_route_table_association" "public" {
+  count          = 2
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}


### PR DESCRIPTION
## Beschreibung

Closes #3

Terraform-Infrastruktur für AWS-Deployment des FORMA Storefronts.

## Infrastruktur

- **ECR** – Docker Registry (`storefront-storefront`)
- **ECS Fargate** – Task Definition (256 CPU / 512 MB) + Service
- **ALB** – Application Load Balancer mit Health Check auf `/api/health`
- **VPC** – Eigenes VPC (10.0.0.0/16) mit 2 public Subnets (multi-AZ)
- **SSM** – Sichere Speicherung von `STRAPI_API_TOKEN` + `N8N_WEBHOOK_URL`
- **IAM** – ECS Task Execution Role mit SSM-Zugriff

## Checkliste

- [x] `terraform/aws/` – Root-Modul mit Provider-Konfiguration
- [x] `terraform/modules/aws/` – Vollständiges Modul (ecr, ecs, alb, vpc, security_groups)
- [x] Sensible Variablen als `sensitive = true` markiert
- [x] Health Check: `GET /api/health` → 200
- [x] `feature-flags.tfvars.example` vorhanden
- [x] Keine Secrets committed