### PR TITLE
feat: Terraform GCP infrastructure (Cloud Run + Artifact Registry)

### DIFF
--- a/terraform/gcp/feature-flags.tfvars.example
+++ b/terraform/gcp/feature-flags.tfvars.example
@@ -1,0 +1,8 @@
+gcp_project_id   = "your-gcp-project-id"
+gcp_region       = "europe-west1"
+project_name     = "storefront"
+image_tag        = "latest"
+strapi_url       = "https://your-strapi-instance.example.com"
+strapi_api_token = "your-strapi-api-token"
+n8n_webhook_url  = "https://your-n8n-instance.example.com/webhook/order-confirmed"
+site_url         = "https://your-storefront.example.com"

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.gcp_project_id
+  region  = var.gcp_region
+}
+
+module "gcp" {
+  source           = "../modules/gcp"
+  gcp_project_id   = var.gcp_project_id
+  gcp_region       = var.gcp_region
+  project_name     = var.project_name
+  image_tag        = var.image_tag
+  strapi_url       = var.strapi_url
+  strapi_api_token = var.strapi_api_token
+  n8n_webhook_url  = var.n8n_webhook_url
+  site_url         = var.site_url
+}

--- a/terraform/gcp/outputs.tf
+++ b/terraform/gcp/outputs.tf
@@ -1,0 +1,9 @@
+output "storefront_url" {
+  description = "Cloud Run service URL"
+  value       = module.gcp.storefront_url
+}
+
+output "artifact_registry_url" {
+  description = "Artifact Registry URL for pushing Docker images"
+  value       = module.gcp.artifact_registry_url
+}

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -1,0 +1,44 @@
+variable "gcp_project_id" {
+  description = "GCP Project ID"
+  type        = string
+}
+
+variable "gcp_region" {
+  description = "GCP region"
+  type        = string
+  default     = "europe-west1"
+}
+
+variable "project_name" {
+  description = "Project name prefix for all resources"
+  type        = string
+  default     = "storefront"
+}
+
+variable "image_tag" {
+  description = "Docker image tag to deploy"
+  type        = string
+  default     = "latest"
+}
+
+variable "strapi_url" {
+  description = "Public URL of the Strapi CMS instance"
+  type        = string
+}
+
+variable "strapi_api_token" {
+  description = "Strapi API token (sensitive)"
+  type        = string
+  sensitive   = true
+}
+
+variable "n8n_webhook_url" {
+  description = "n8n webhook URL for order notifications"
+  type        = string
+  sensitive   = true
+}
+
+variable "site_url" {
+  description = "Public URL of the storefront"
+  type        = string
+}

--- a/terraform/modules/gcp/apis.tf
+++ b/terraform/modules/gcp/apis.tf
@@ -1,0 +1,17 @@
+resource "google_project_service" "run" {
+  project            = var.gcp_project_id
+  service            = "run.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "artifactregistry" {
+  project            = var.gcp_project_id
+  service            = "artifactregistry.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "secretmanager" {
+  project            = var.gcp_project_id
+  service            = "secretmanager.googleapis.com"
+  disable_on_destroy = false
+}

--- a/terraform/modules/gcp/cloudrun.tf
+++ b/terraform/modules/gcp/cloudrun.tf
@@ -1,0 +1,113 @@
+data "google_compute_default_service_account" "default" {
+  project = var.gcp_project_id
+}
+
+resource "google_cloud_run_v2_service" "storefront" {
+  project  = var.gcp_project_id
+  name     = "${var.project_name}-storefront"
+  location = var.gcp_region
+
+  template {
+    scaling {
+      min_instance_count = 1
+      max_instance_count = 3
+    }
+
+    containers {
+      image = "${var.gcp_region}-docker.pkg.dev/${var.gcp_project_id}/${var.project_name}-storefront/app:${var.image_tag}"
+
+      ports {
+        container_port = 3000
+      }
+
+      resources {
+        limits = {
+          memory = "512Mi"
+          cpu    = "1"
+        }
+      }
+
+      env {
+        name  = "NEXT_PUBLIC_STRAPI_URL"
+        value = var.strapi_url
+      }
+
+      env {
+        name  = "NEXT_PUBLIC_SITE_URL"
+        value = var.site_url
+      }
+
+      env {
+        name  = "NODE_ENV"
+        value = "production"
+      }
+
+      env {
+        name = "STRAPI_API_TOKEN"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.strapi_api_token.secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name = "N8N_WEBHOOK_URL"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.n8n_webhook_url.secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      startup_probe {
+        http_get {
+          path = "/api/health"
+          port = 3000
+        }
+        initial_delay_seconds = 10
+        period_seconds        = 5
+        failure_threshold     = 3
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/api/health"
+          port = 3000
+        }
+        period_seconds    = 30
+        failure_threshold = 3
+      }
+    }
+  }
+
+  depends_on = [
+    google_project_service.run,
+    google_secret_manager_secret_version.strapi_api_token,
+    google_secret_manager_secret_version.n8n_webhook_url,
+  ]
+}
+
+resource "google_cloud_run_v2_service_iam_member" "public" {
+  project  = var.gcp_project_id
+  location = var.gcp_region
+  name     = google_cloud_run_v2_service.storefront.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+resource "google_secret_manager_secret_iam_member" "strapi_token_run" {
+  project   = var.gcp_project_id
+  secret_id = google_secret_manager_secret.strapi_api_token.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${data.google_compute_default_service_account.default.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "n8n_url_run" {
+  project   = var.gcp_project_id
+  secret_id = google_secret_manager_secret.n8n_webhook_url.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${data.google_compute_default_service_account.default.email}"
+}

--- a/terraform/modules/gcp/outputs.tf
+++ b/terraform/modules/gcp/outputs.tf
@@ -1,0 +1,9 @@
+output "storefront_url" {
+  description = "Cloud Run service URL"
+  value       = google_cloud_run_v2_service.storefront.uri
+}
+
+output "artifact_registry_url" {
+  description = "Artifact Registry URL for pushing Docker images"
+  value       = "${var.gcp_region}-docker.pkg.dev/${var.gcp_project_id}/${var.project_name}-storefront/app"
+}

--- a/terraform/modules/gcp/registry.tf
+++ b/terraform/modules/gcp/registry.tf
@@ -1,0 +1,9 @@
+resource "google_artifact_registry_repository" "storefront" {
+  project       = var.gcp_project_id
+  location      = var.gcp_region
+  repository_id = "${var.project_name}-storefront"
+  description   = "Docker images for omniops storefront"
+  format        = "DOCKER"
+
+  depends_on = [google_project_service.artifactregistry]
+}

--- a/terraform/modules/gcp/secrets.tf
+++ b/terraform/modules/gcp/secrets.tf
@@ -1,0 +1,31 @@
+resource "google_secret_manager_secret" "strapi_api_token" {
+  project   = var.gcp_project_id
+  secret_id = "${var.project_name}-strapi-api-token"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.secretmanager]
+}
+
+resource "google_secret_manager_secret_version" "strapi_api_token" {
+  secret      = google_secret_manager_secret.strapi_api_token.id
+  secret_data = var.strapi_api_token
+}
+
+resource "google_secret_manager_secret" "n8n_webhook_url" {
+  project   = var.gcp_project_id
+  secret_id = "${var.project_name}-n8n-webhook-url"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.secretmanager]
+}
+
+resource "google_secret_manager_secret_version" "n8n_webhook_url" {
+  secret      = google_secret_manager_secret.n8n_webhook_url.id
+  secret_data = var.n8n_webhook_url
+}

--- a/terraform/modules/gcp/variables.tf
+++ b/terraform/modules/gcp/variables.tf
@@ -1,0 +1,41 @@
+variable "gcp_project_id" {
+  description = "GCP Project ID"
+  type        = string
+}
+
+variable "gcp_region" {
+  description = "GCP region"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name prefix for all resources"
+  type        = string
+}
+
+variable "image_tag" {
+  description = "Docker image tag to deploy"
+  type        = string
+}
+
+variable "strapi_url" {
+  description = "Public URL of the Strapi CMS instance"
+  type        = string
+}
+
+variable "strapi_api_token" {
+  description = "Strapi API token (sensitive)"
+  type        = string
+  sensitive   = true
+}
+
+variable "n8n_webhook_url" {
+  description = "n8n webhook URL for order notifications"
+  type        = string
+  sensitive   = true
+}
+
+variable "site_url" {
+  description = "Public URL of the storefront"
+  type        = string
+}


### PR DESCRIPTION
## Beschreibung

Closes #4

Terraform-Infrastruktur für GCP-Deployment des FORMA Storefronts.

## Infrastruktur

- **Artifact Registry** – Docker Registry (`storefront-storefront`, Format: DOCKER)
- **Cloud Run v2** – Service mit 1–3 Instanzen (512Mi / 1 CPU), Startup- + Liveness-Probe
- **Secret Manager** – `STRAPI_API_TOKEN` + `N8N_WEBHOOK_URL` als Secrets
- **APIs aktiviert** – `run.googleapis.com`, `artifactregistry.googleapis.com`, `secretmanager.googleapis.com`
- **IAM** – Public Access + Secret Accessor für Cloud Run Service Account

## Checkliste

- [x] `terraform/gcp/` – Root-Modul
- [x] `terraform/modules/gcp/` – Vollständiges Modul (apis, registry, secrets, cloudrun)
- [x] Sensible Variablen als `sensitive = true` markiert
- [x] Health Check: `GET /api/health` als Startup- + Liveness-Probe
- [x] `feature-flags.tfvars.example` vorhanden
- [x] Keine Secrets committed