### PR TITLE
feat: typed Strapi API client and TypeScript interfaces

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  return NextResponse.json(
+    { status: 'ok', timestamp: new Date().toISOString() },
+    { status: 200 }
+  );
+}

--- a/src/lib/n8n.ts
+++ b/src/lib/n8n.ts
@@ -1,0 +1,39 @@
+export interface OrderPayload {
+  customerEmail: string;
+  customerName: string;
+  productName: string;
+  totalAmount: number;
+}
+
+/**
+ * Sendet eine Bestellbestätigung an n8n.
+ * Server-only: liest N8N_WEBHOOK_URL aus process.env.
+ * Graceful Degradation: Fehler werden geloggt, nicht geworfen.
+ */
+export async function postOrderConfirmed(payload: OrderPayload): Promise<void> {
+  const webhookUrl = process.env.N8N_WEBHOOK_URL;
+
+  if (!webhookUrl) {
+    console.warn('[n8n] N8N_WEBHOOK_URL not configured – skipping order notification');
+    return;
+  }
+
+  try {
+    const response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        customerEmail: payload.customerEmail,
+        customerName: payload.customerName,
+        productName: payload.productName,
+        totalAmount: payload.totalAmount,
+      }),
+    });
+
+    if (!response.ok) {
+      console.error(`[n8n] Webhook failed: ${response.status} ${response.statusText}`);
+    }
+  } catch (error) {
+    console.error('[n8n] Webhook error (non-blocking):', error);
+  }
+}

--- a/src/lib/strapi-types.ts
+++ b/src/lib/strapi-types.ts
@@ -1,0 +1,292 @@
+// ============================================================
+// Strapi 5 Base Types
+// ============================================================
+
+export interface StrapiMeta {
+  pagination?: {
+    page: number;
+    pageSize: number;
+    pageCount: number;
+    total: number;
+  };
+}
+
+export interface StrapiSingleResponse<T> {
+  data: T;
+  meta: StrapiMeta;
+}
+
+export interface StrapiListResponse<T> {
+  data: T[];
+  meta: StrapiMeta;
+}
+
+export interface StrapiImage {
+  id: number;
+  documentId: string;
+  url: string;
+  alternativeText: string | null;
+  caption: string | null;
+  width: number;
+  height: number;
+  formats: {
+    thumbnail?: StrapiImageFormat;
+    small?: StrapiImageFormat;
+    medium?: StrapiImageFormat;
+    large?: StrapiImageFormat;
+  };
+}
+
+interface StrapiImageFormat {
+  url: string;
+  width: number;
+  height: number;
+}
+
+// ============================================================
+// SEO
+// ============================================================
+
+export interface SeoMetadata {
+  id: number;
+  meta_title: string | null;
+  meta_description: string | null;
+  og_image: StrapiImage | null;
+  canonical_url: string | null;
+  no_index: boolean;
+}
+
+// ============================================================
+// Product
+// ============================================================
+
+export interface ProductOptionValue {
+  id: number;
+  documentId: string;
+  value: string;
+  position: number;
+}
+
+export interface ProductOption {
+  id: number;
+  documentId: string;
+  name: string;
+  position: number;
+  values: ProductOptionValue[];
+}
+
+export interface ProductVariant {
+  id: number;
+  documentId: string;
+  sku: string;
+  price: number;
+  compare_at_price: number | null;
+  stock_quantity: number;
+  selected_options: Record<string, string>;
+  image: StrapiImage | null;
+  is_active: boolean;
+}
+
+export interface Product {
+  id: number;
+  documentId: string;
+  name: string;
+  slug: string;
+  description: string;
+  short_description: string | null;
+  images: StrapiImage[];
+  categories: Category[];
+  variants: ProductVariant[];
+  options: ProductOption[];
+  seo: SeoMetadata | null;
+  createdAt: string;
+  updatedAt: string;
+  publishedAt: string | null;
+}
+
+// ============================================================
+// Category
+// ============================================================
+
+export interface Category {
+  id: number;
+  documentId: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  image: StrapiImage | null;
+  parent: Category | null;
+  children: Category[];
+  products: Product[];
+  seo: SeoMetadata | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ============================================================
+// Blog Post
+// ============================================================
+
+export interface BlogPost {
+  id: number;
+  documentId: string;
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  content: string;
+  cover_image: StrapiImage | null;
+  author: string | null;
+  reading_time_minutes: number | null;
+  category_tags: string[];
+  seo: SeoMetadata | null;
+  createdAt: string;
+  updatedAt: string;
+  publishedAt: string | null;
+}
+
+// ============================================================
+// Landing Page Sections
+// ============================================================
+
+export interface HeroBannerSection {
+  __component: 'sections.hero-banner';
+  id: number;
+  headline: string;
+  subheadline: string | null;
+  cta_text: string | null;
+  cta_url: string | null;
+  background_image: StrapiImage | null;
+}
+
+export interface ProductPlacementSection {
+  __component: 'sections.product-placement';
+  id: number;
+  title: string;
+  products: Product[];
+}
+
+export interface CtaBlockSection {
+  __component: 'sections.cta-block';
+  id: number;
+  headline: string;
+  body: string | null;
+  cta_text: string;
+  cta_url: string;
+}
+
+export interface TextBlockSection {
+  __component: 'sections.text-block';
+  id: number;
+  content: string;
+}
+
+export interface ImageTextSection {
+  __component: 'sections.image-text';
+  id: number;
+  image: StrapiImage;
+  headline: string;
+  body: string;
+  image_position: 'left' | 'right';
+}
+
+export interface ImageGallerySection {
+  __component: 'sections.image-gallery';
+  id: number;
+  images: StrapiImage[];
+}
+
+export interface TestimonialsSection {
+  __component: 'sections.testimonials';
+  id: number;
+  testimonials: Array<{
+    id: number;
+    author: string;
+    quote: string;
+    role: string | null;
+  }>;
+}
+
+export interface FaqSection {
+  __component: 'sections.faq';
+  id: number;
+  items: Array<{
+    id: number;
+    question: string;
+    answer: string;
+  }>;
+}
+
+export type LandingPageSection =
+  | HeroBannerSection
+  | ProductPlacementSection
+  | CtaBlockSection
+  | TextBlockSection
+  | ImageTextSection
+  | ImageGallerySection
+  | TestimonialsSection
+  | FaqSection;
+
+// ============================================================
+// Landing Page
+// ============================================================
+
+export interface LandingPage {
+  id: number;
+  documentId: string;
+  title: string;
+  slug: string;
+  sections: LandingPageSection[];
+  seo: SeoMetadata | null;
+  createdAt: string;
+  updatedAt: string;
+  publishedAt: string | null;
+}
+
+// ============================================================
+// Navigation
+// ============================================================
+
+export interface NavItem {
+  id: number;
+  label: string;
+  url: string;
+  open_in_new_tab: boolean;
+  children?: NavItem[];
+}
+
+export interface Navigation {
+  id: number;
+  documentId: string;
+  name: string;
+  identifier: string;
+  items: NavItem[];
+}
+
+// ============================================================
+// Global Settings
+// ============================================================
+
+export interface GlobalSetting {
+  id: number;
+  documentId: string;
+  shop_name: string;
+  currency: string;
+}
+
+// ============================================================
+// Query Params
+// ============================================================
+
+export interface StrapiQueryParams {
+  populate?: string | string[] | Record<string, unknown>;
+  filters?: Record<string, unknown>;
+  pagination?: {
+    page?: number;
+    pageSize?: number;
+    start?: number;
+    limit?: number;
+  };
+  sort?: string | string[];
+  fields?: string[];
+  locale?: string;
+}

--- a/src/lib/strapi.ts
+++ b/src/lib/strapi.ts
@@ -1,0 +1,212 @@
+import type {
+  StrapiListResponse,
+  StrapiSingleResponse,
+  StrapiQueryParams,
+  Product,
+  Category,
+  BlogPost,
+  LandingPage,
+  Navigation,
+  GlobalSetting,
+} from './strapi-types';
+
+function buildQueryString(params: StrapiQueryParams): string {
+  const searchParams = new URLSearchParams();
+
+  if (params.pagination) {
+    const p = params.pagination;
+    if (p.page !== undefined) searchParams.set('pagination[page]', String(p.page));
+    if (p.pageSize !== undefined) searchParams.set('pagination[pageSize]', String(p.pageSize));
+    if (p.start !== undefined) searchParams.set('pagination[start]', String(p.start));
+    if (p.limit !== undefined) searchParams.set('pagination[limit]', String(p.limit));
+  }
+
+  if (params.sort) {
+    const sorts = Array.isArray(params.sort) ? params.sort : [params.sort];
+    sorts.forEach((s, i) => searchParams.set(`sort[${i}]`, s));
+  }
+
+  if (params.fields) {
+    params.fields.forEach((f, i) => searchParams.set(`fields[${i}]`, f));
+  }
+
+  if (params.locale) {
+    searchParams.set('locale', params.locale);
+  }
+
+  if (params.populate) {
+    if (typeof params.populate === 'string') {
+      searchParams.set('populate', params.populate);
+    } else if (Array.isArray(params.populate)) {
+      params.populate.forEach((p, i) => searchParams.set(`populate[${i}]`, p));
+    }
+  }
+
+  if (params.filters) {
+    const flattenFilters = (obj: Record<string, unknown>, prefix = 'filters') => {
+      for (const [key, value] of Object.entries(obj)) {
+        const paramKey = `${prefix}[${key}]`;
+        if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+          flattenFilters(value as Record<string, unknown>, paramKey);
+        } else {
+          searchParams.set(paramKey, String(value));
+        }
+      }
+    };
+    flattenFilters(params.filters);
+  }
+
+  const qs = searchParams.toString();
+  return qs ? `?${qs}` : '';
+}
+
+async function fetchStrapi<T>(
+  path: string,
+  params: StrapiQueryParams = {},
+  options: RequestInit = {}
+): Promise<T> {
+  const baseUrl = process.env.NEXT_PUBLIC_STRAPI_URL ?? 'http://localhost:1337';
+  const queryString = buildQueryString(params);
+  const url = `${baseUrl}/api${path}${queryString}`;
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...(options.headers as Record<string, string>),
+  };
+
+  // STRAPI_API_TOKEN ist Server-only – kein NEXT_PUBLIC_ Prefix
+  // Guard verhindert, dass der Token im Browser-Bundle landet
+  if (typeof window === 'undefined' && process.env.STRAPI_API_TOKEN) {
+    headers['Authorization'] = `Bearer ${process.env.STRAPI_API_TOKEN}`;
+  }
+
+  const response = await fetch(url, {
+    ...options,
+    headers,
+    next: { revalidate: 60 },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Strapi API error: ${response.status} ${response.statusText} – ${url}`
+    );
+  }
+
+  return response.json() as Promise<T>;
+}
+
+// ============================================================
+// Products
+// ============================================================
+
+export async function getProducts(
+  params: StrapiQueryParams = {}
+): Promise<StrapiListResponse<Product>> {
+  return fetchStrapi<StrapiListResponse<Product>>('/products', {
+    populate: ['images', 'categories', 'variants', 'options', 'seo'],
+    ...params,
+  });
+}
+
+export async function getProductBySlug(
+  slug: string
+): Promise<StrapiSingleResponse<Product> | null> {
+  const response = await fetchStrapi<StrapiListResponse<Product>>('/products', {
+    filters: { slug: { $eq: slug } },
+    populate: ['images', 'categories', 'variants', 'variants.image', 'options', 'options.values', 'seo'],
+  });
+  if (!response.data.length) return null;
+  return { data: response.data[0], meta: response.meta };
+}
+
+// ============================================================
+// Categories
+// ============================================================
+
+export async function getCategories(
+  params: StrapiQueryParams = {}
+): Promise<StrapiListResponse<Category>> {
+  return fetchStrapi<StrapiListResponse<Category>>('/categories', {
+    populate: ['image', 'parent', 'seo'],
+    ...params,
+  });
+}
+
+export async function getCategoryBySlug(
+  slug: string
+): Promise<StrapiSingleResponse<Category> | null> {
+  const response = await fetchStrapi<StrapiListResponse<Category>>('/categories', {
+    filters: { slug: { $eq: slug } },
+    populate: ['image', 'parent', 'children', 'seo'],
+  });
+  if (!response.data.length) return null;
+  return { data: response.data[0], meta: response.meta };
+}
+
+// ============================================================
+// Blog Posts
+// ============================================================
+
+export async function getBlogPosts(
+  params: StrapiQueryParams = {}
+): Promise<StrapiListResponse<BlogPost>> {
+  return fetchStrapi<StrapiListResponse<BlogPost>>('/blog-posts', {
+    populate: ['cover_image', 'seo'],
+    sort: ['publishedAt:desc'],
+    ...params,
+  });
+}
+
+export async function getBlogPostBySlug(
+  slug: string
+): Promise<StrapiSingleResponse<BlogPost> | null> {
+  const response = await fetchStrapi<StrapiListResponse<BlogPost>>('/blog-posts', {
+    filters: { slug: { $eq: slug } },
+    populate: ['cover_image', 'seo'],
+  });
+  if (!response.data.length) return null;
+  return { data: response.data[0], meta: response.meta };
+}
+
+// ============================================================
+// Landing Page
+// ============================================================
+
+export async function getLandingPage(
+  slug: string
+): Promise<StrapiSingleResponse<LandingPage> | null> {
+  const response = await fetchStrapi<StrapiListResponse<LandingPage>>('/landing-pages', {
+    filters: { slug: { $eq: slug } },
+    populate: {
+      sections: { populate: '*' },
+      seo: { populate: ['og_image'] },
+    },
+  });
+  if (!response.data.length) return null;
+  return { data: response.data[0], meta: response.meta };
+}
+
+// ============================================================
+// Navigation
+// ============================================================
+
+export async function getNavigation(
+  identifier: string
+): Promise<StrapiSingleResponse<Navigation> | null> {
+  const response = await fetchStrapi<StrapiListResponse<Navigation>>('/navigations', {
+    filters: { identifier: { $eq: identifier } },
+    populate: { items: { populate: ['children'] } },
+  });
+  if (!response.data.length) return null;
+  return { data: response.data[0], meta: response.meta };
+}
+
+// ============================================================
+// Global Settings
+// ============================================================
+
+export async function getGlobalSettings(): Promise<StrapiSingleResponse<GlobalSetting>> {
+  return fetchStrapi<StrapiSingleResponse<GlobalSetting>>('/global-setting', {
+    populate: '*',
+  });
+}


### PR DESCRIPTION
## Beschreibung

Closes #6

Typisierter Strapi REST API Client, alle TypeScript-Interfaces für omniops-os eCommerce Content-Types, n8n Webhook Helper und Health-Check Endpoint.

## Änderungen

- `src/lib/strapi-types.ts` – Vollständige TypeScript-Interfaces (Product, Category, BlogPost, LandingPage, Navigation, GlobalSetting, alle Section-Types)
- `src/lib/strapi.ts` – Typisierter API Client mit Query-Builder + alle API-Funktionen (getProducts, getProductBySlug, getCategories, getBlogPosts, getLandingPage, getNavigation, getGlobalSettings)
- `src/lib/n8n.ts` – Order-Notification Webhook Helper (server-only, graceful degradation)
- `src/app/api/health/route.ts` – `GET /api/health` → 200 OK + timestamp

## Sicherheit

- `STRAPI_API_TOKEN` wird **nur server-seitig** via `typeof window === 'undefined'` Guard gesetzt
- Kein `NEXT_PUBLIC_` Prefix – Token erscheint nicht im Browser-Bundle

## Checkliste

- [x] TypeScript – alle Types korrekt
- [x] `GET /api/health` → `{ status: 'ok', timestamp: '...' }`
- [x] Strapi API Token nicht im Browser-Bundle
- [x] n8n Webhook: graceful degradation wenn URL nicht konfiguriert
- [x] Keine Secrets committed