### PR TITLE
feat: FORMA brand design system and UI component library

### DIFF
--- a/src/components/blog/BlogCard.tsx
+++ b/src/components/blog/BlogCard.tsx
@@ -1,0 +1,61 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import type { BlogPost } from '@/lib/strapi-types';
+
+interface BlogCardProps {
+  post: BlogPost;
+}
+
+export function BlogCard({ post }: BlogCardProps) {
+  const { title, slug, excerpt, cover_image, author, reading_time_minutes, publishedAt } =
+    post;
+  const strapiUrl = process.env.NEXT_PUBLIC_STRAPI_URL ?? '';
+
+  const formattedDate = publishedAt
+    ? new Intl.DateTimeFormat('de-DE', {
+        day: '2-digit',
+        month: 'long',
+        year: 'numeric',
+      }).format(new Date(publishedAt))
+    : null;
+
+  return (
+    <Link href={`/blog/${slug}`} className="group block">
+      {cover_image && (
+        <div className="relative aspect-[16/9] overflow-hidden bg-muted mb-5">
+          <Image
+            src={`${strapiUrl}${cover_image.url}`}
+            alt={cover_image.alternativeText ?? title}
+            fill
+            className="object-cover transition-transform duration-500 group-hover:scale-105"
+          />
+        </div>
+      )}
+
+      <div className="flex items-center gap-4 mb-3">
+        {formattedDate && (
+          <span className="font-mono text-xs text-foreground/50">{formattedDate}</span>
+        )}
+        {reading_time_minutes && (
+          <span className="font-mono text-xs text-foreground/50">
+            {reading_time_minutes} Min. Lesezeit
+          </span>
+        )}
+      </div>
+
+      <h3 className="font-serif text-2xl text-foreground group-hover:text-accent transition-colors mb-3 leading-snug">
+        {title}
+      </h3>
+
+      {excerpt && (
+        <p className="font-sans text-foreground/60 line-clamp-3 leading-relaxed">{excerpt}</p>
+      )}
+
+      {author && (
+        <p className="font-mono text-xs uppercase tracking-wider text-foreground/40 mt-4">
+          {author}
+        </p>
+      )}
+    </Link>
+  );
+}

--- a/src/components/blog/BlogGrid.tsx
+++ b/src/components/blog/BlogGrid.tsx
@@ -1,0 +1,24 @@
+import type { BlogPost } from '@/lib/strapi-types';
+import { BlogCard } from './BlogCard';
+
+interface BlogGridProps {
+  posts: BlogPost[];
+}
+
+export function BlogGrid({ posts }: BlogGridProps) {
+  if (!posts.length) {
+    return (
+      <p className="font-mono text-sm text-foreground/40 uppercase tracking-wider py-12 text-center">
+        Keine Beiträge gefunden
+      </p>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-12 md:grid-cols-2 lg:grid-cols-3">
+      {posts.map((post) => (
+        <BlogCard key={post.documentId} post={post} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/checkout/CheckoutForm.tsx
+++ b/src/components/checkout/CheckoutForm.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useTranslations } from 'next-intl';
+import { Button } from '@/components/ui/Button';
+import { Konfetti } from '@/components/ui/Konfetti';
+
+interface FormData {
+  firstName: string;
+  email: string;
+  company?: string;
+}
+
+interface CheckoutFormProps {
+  productName: string;
+  productId: string;
+  variantId?: string;
+  price: number;
+}
+
+export function CheckoutForm({
+  productName,
+  productId,
+  variantId,
+  price,
+}: CheckoutFormProps) {
+  const t = useTranslations('checkout');
+  const [success, setSuccess] = useState(false);
+  const [apiError, setApiError] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    getValues,
+    formState: { errors, isSubmitting },
+  } = useForm<FormData>();
+
+  async function onSubmit(data: FormData) {
+    setApiError(null);
+    try {
+      const res = await fetch('/api/checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...data, productId, variantId, price }),
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setApiError(body.message ?? 'Fehler bei der Bestellung');
+        return;
+      }
+
+      setSuccess(true);
+    } catch {
+      setApiError('Netzwerkfehler – bitte versuche es erneut');
+    }
+  }
+
+  if (success) {
+    return (
+      <div className="py-12 text-center">
+        <Konfetti />
+        <h2 className="font-serif text-3xl text-foreground mb-4">{t('success.title')}</h2>
+        <p className="font-sans text-foreground/70">
+          {t('success.message', { email: getValues('email') })}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-6">
+      {/* Vorname */}
+      <div>
+        <label className="font-mono text-xs uppercase tracking-wider text-foreground block mb-2">
+          {t('firstName')} *
+        </label>
+        <input
+          {...register('firstName', { required: true, minLength: 1 })}
+          className="w-full border border-muted bg-background px-4 py-3 font-sans text-foreground focus:outline-none focus:border-foreground transition-colors"
+        />
+        {errors.firstName && (
+          <p className="font-mono text-xs text-accent mt-1">{t('errors.required')}</p>
+        )}
+      </div>
+
+      {/* E-Mail */}
+      <div>
+        <label className="font-mono text-xs uppercase tracking-wider text-foreground block mb-2">
+          {t('email')} *
+        </label>
+        <input
+          {...register('email', {
+            required: true,
+            pattern: { value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/, message: 'invalid' },
+          })}
+          type="email"
+          className="w-full border border-muted bg-background px-4 py-3 font-sans text-foreground focus:outline-none focus:border-foreground transition-colors"
+        />
+        {errors.email && (
+          <p className="font-mono text-xs text-accent mt-1">{t('errors.invalidEmail')}</p>
+        )}
+      </div>
+
+      {/* Unternehmen (optional) */}
+      <div>
+        <label className="font-mono text-xs uppercase tracking-wider text-foreground block mb-2">
+          Unternehmen
+        </label>
+        <input
+          {...register('company')}
+          className="w-full border border-muted bg-background px-4 py-3 font-sans text-foreground focus:outline-none focus:border-foreground transition-colors"
+        />
+      </div>
+
+      {/* Produkt (readonly) */}
+      <div>
+        <label className="font-mono text-xs uppercase tracking-wider text-foreground/50 block mb-2">
+          Produkt
+        </label>
+        <input
+          value={productName}
+          readOnly
+          className="w-full border border-muted bg-muted px-4 py-3 font-sans text-foreground/60 cursor-not-allowed"
+        />
+      </div>
+
+      {apiError && (
+        <p className="font-mono text-xs text-accent border border-accent px-4 py-3">
+          {apiError}
+        </p>
+      )}
+
+      <Button type="submit" variant="primary" size="lg" loading={isSubmitting}>
+        {t('submit')}
+      </Button>
+    </form>
+  );
+}

--- a/src/components/checkout/OrderSummary.tsx
+++ b/src/components/checkout/OrderSummary.tsx
@@ -1,0 +1,36 @@
+import { PriceDisplay } from '@/components/product/PriceDisplay';
+
+interface OrderSummaryProps {
+  productName: string;
+  variantLabel?: string;
+  price: number;
+  currency?: string;
+}
+
+export function OrderSummary({
+  productName,
+  variantLabel,
+  price,
+  currency = 'EUR',
+}: OrderSummaryProps) {
+  return (
+    <div className="border border-muted p-6 bg-background">
+      <h3 className="font-mono text-xs uppercase tracking-wider text-foreground/60 mb-4">
+        Bestellübersicht
+      </h3>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="font-sans font-medium text-foreground">{productName}</p>
+          {variantLabel && (
+            <p className="font-mono text-xs text-foreground/50 mt-1">{variantLabel}</p>
+          )}
+        </div>
+        <PriceDisplay price={price} currency={currency} />
+      </div>
+      <div className="mt-6 pt-4 border-t border-muted flex items-center justify-between">
+        <span className="font-mono text-sm uppercase tracking-wider text-foreground">Gesamt</span>
+        <PriceDisplay price={price} currency={currency} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/product/PriceDisplay.tsx
+++ b/src/components/product/PriceDisplay.tsx
@@ -1,0 +1,34 @@
+interface PriceDisplayProps {
+  price: number;
+  compareAtPrice?: number | null;
+  currency?: string;
+  className?: string;
+}
+
+export function PriceDisplay({
+  price,
+  compareAtPrice,
+  currency = 'EUR',
+  className = '',
+}: PriceDisplayProps) {
+  const formatPrice = (amount: number) =>
+    new Intl.NumberFormat('de-DE', {
+      style: 'currency',
+      currency,
+    }).format(amount / 100);
+
+  const hasDiscount = compareAtPrice && compareAtPrice > price;
+
+  return (
+    <div className={`flex items-baseline gap-2 ${className}`}>
+      <span className="font-mono text-foreground">
+        {formatPrice(price)}
+      </span>
+      {hasDiscount && (
+        <span className="font-mono text-sm text-foreground/40 line-through">
+          {formatPrice(compareAtPrice)}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/product/ProductCard.tsx
+++ b/src/components/product/ProductCard.tsx
@@ -1,0 +1,69 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import type { Product } from '@/lib/strapi-types';
+import { Badge } from '@/components/ui/Badge';
+import { PriceDisplay } from './PriceDisplay';
+
+interface ProductCardProps {
+  product: Product;
+}
+
+export function ProductCard({ product }: ProductCardProps) {
+  const { name, slug, short_description, images, variants } = product;
+  const strapiUrl = process.env.NEXT_PUBLIC_STRAPI_URL ?? '';
+
+  const coverImage = images?.[0];
+  const activeVariants = variants?.filter((v) => v.is_active) ?? [];
+  const lowestPrice = activeVariants.length
+    ? Math.min(...activeVariants.map((v) => v.price))
+    : null;
+  const hasCompareAt = activeVariants.some((v) => v.compare_at_price);
+  const compareAtPrice = hasCompareAt
+    ? Math.min(...activeVariants.filter((v) => v.compare_at_price).map((v) => v.compare_at_price!))
+    : null;
+
+  const isNew = !product.publishedAt || new Date(product.publishedAt) > new Date(Date.now() - 14 * 24 * 60 * 60 * 1000);
+  const isSoldOut = activeVariants.every((v) => v.stock_quantity === 0);
+  const isOnSale = hasCompareAt;
+
+  return (
+    <Link href={`/shop/${slug}`} className="group block">
+      <div className="relative aspect-square overflow-hidden bg-muted mb-4">
+        {coverImage ? (
+          <Image
+            src={`${strapiUrl}${coverImage.url}`}
+            alt={coverImage.alternativeText ?? name}
+            fill
+            className="object-cover transition-transform duration-500 group-hover:scale-105"
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center">
+            <span className="font-mono text-xs text-foreground/30 uppercase tracking-wider">
+              Kein Bild
+            </span>
+          </div>
+        )}
+
+        <div className="absolute top-3 left-3 flex flex-col gap-1">
+          {isSoldOut && <Badge variant="error">Ausverkauft</Badge>}
+          {!isSoldOut && isOnSale && <Badge variant="warning">Sale</Badge>}
+          {!isSoldOut && isNew && !isOnSale && <Badge variant="default">Neu</Badge>}
+        </div>
+      </div>
+
+      <div>
+        <h3 className="font-sans font-medium text-foreground group-hover:text-accent transition-colors mb-1">
+          {name}
+        </h3>
+        {short_description && (
+          <p className="font-sans text-sm text-foreground/60 mb-2 line-clamp-2">
+            {short_description}
+          </p>
+        )}
+        {lowestPrice !== null && (
+          <PriceDisplay price={lowestPrice} compareAtPrice={compareAtPrice} />
+        )}
+      </div>
+    </Link>
+  );
+}

--- a/src/components/product/ProductGallery.tsx
+++ b/src/components/product/ProductGallery.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import Image from 'next/image';
+import { useState } from 'react';
+import type { StrapiImage } from '@/lib/strapi-types';
+
+interface ProductGalleryProps {
+  images: StrapiImage[];
+  productName: string;
+}
+
+export function ProductGallery({ images, productName }: ProductGalleryProps) {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const strapiUrl = process.env.NEXT_PUBLIC_STRAPI_URL ?? '';
+
+  if (!images.length) return null;
+
+  const activeImage = images[activeIndex];
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Main Image */}
+      <div className="relative aspect-square overflow-hidden bg-muted">
+        <Image
+          src={`${strapiUrl}${activeImage.url}`}
+          alt={activeImage.alternativeText ?? productName}
+          fill
+          className="object-cover"
+          priority
+        />
+      </div>
+
+      {/* Thumbnails */}
+      {images.length > 1 && (
+        <div className="flex gap-3">
+          {images.map((image, i) => (
+            <button
+              key={image.id}
+              onClick={() => setActiveIndex(i)}
+              className={[
+                'relative w-20 h-20 flex-shrink-0 overflow-hidden border-2 transition-colors',
+                i === activeIndex ? 'border-foreground' : 'border-transparent hover:border-muted',
+              ].join(' ')}
+            >
+              <Image
+                src={`${strapiUrl}${image.url}`}
+                alt={image.alternativeText ?? productName}
+                fill
+                className="object-cover"
+              />
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/product/ProductGrid.tsx
+++ b/src/components/product/ProductGrid.tsx
@@ -1,0 +1,30 @@
+import type { Product } from '@/lib/strapi-types';
+import { ProductCard } from './ProductCard';
+
+interface ProductGridProps {
+  products: Product[];
+  columns?: 3 | 4;
+}
+
+export function ProductGrid({ products, columns = 3 }: ProductGridProps) {
+  if (!products.length) {
+    return (
+      <p className="font-mono text-sm text-foreground/40 uppercase tracking-wider py-12 text-center">
+        Keine Produkte gefunden
+      </p>
+    );
+  }
+
+  return (
+    <div
+      className={[
+        'grid grid-cols-1 gap-8 sm:grid-cols-2',
+        columns === 4 ? 'lg:grid-cols-4' : 'lg:grid-cols-3',
+      ].join(' ')}
+    >
+      {products.map((product) => (
+        <ProductCard key={product.documentId} product={product} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/product/VariantSelector.tsx
+++ b/src/components/product/VariantSelector.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import type { ProductOption, ProductVariant } from '@/lib/strapi-types';
+
+interface VariantSelectorProps {
+  options: ProductOption[];
+  variants: ProductVariant[];
+  selectedOptions: Record<string, string>;
+  onSelect: (optionName: string, value: string) => void;
+}
+
+export function VariantSelector({
+  options,
+  variants,
+  selectedOptions,
+  onSelect,
+}: VariantSelectorProps) {
+  function isValueAvailable(optionName: string, value: string): boolean {
+    const testOptions = { ...selectedOptions, [optionName]: value };
+    return variants.some((v) => {
+      if (!v.is_active) return false;
+      if (v.stock_quantity === 0) return false;
+      return Object.entries(testOptions).every(
+        ([key, val]) => v.selected_options[key] === val
+      );
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {options.map((option) => (
+        <div key={option.id}>
+          <p className="font-mono text-xs uppercase tracking-wider text-foreground mb-3">
+            {option.name}
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {option.values.map((val) => {
+              const available = isValueAvailable(option.name, val.value);
+              const selected = selectedOptions[option.name] === val.value;
+
+              return (
+                <button
+                  key={val.id}
+                  onClick={() => available && onSelect(option.name, val.value)}
+                  disabled={!available}
+                  className={[
+                    'px-4 py-2 font-mono text-sm border transition-colors',
+                    selected
+                      ? 'border-foreground bg-foreground text-background'
+                      : available
+                      ? 'border-muted text-foreground hover:border-foreground'
+                      : 'border-muted text-foreground/30 line-through cursor-not-allowed',
+                  ].join(' ')}
+                >
+                  {val.value}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/sections/CtaBlock.tsx
+++ b/src/components/sections/CtaBlock.tsx
@@ -1,0 +1,26 @@
+import type { CtaBlockSection } from '@/lib/strapi-types';
+import { Button } from '@/components/ui/Button';
+
+interface CtaBlockProps {
+  section: CtaBlockSection;
+}
+
+export function CtaBlock({ section }: CtaBlockProps) {
+  const { headline, body, cta_text, cta_url } = section;
+
+  return (
+    <section className="bg-foreground text-background py-20">
+      <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 text-center">
+        <h2 className="font-serif text-4xl mb-6">{headline}</h2>
+        {body && (
+          <p className="font-sans text-lg text-background/70 mb-10 leading-relaxed">{body}</p>
+        )}
+        <a href={cta_url}>
+          <Button variant="secondary" size="lg" className="border-background text-background hover:bg-background hover:text-foreground">
+            {cta_text}
+          </Button>
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/Faq.tsx
+++ b/src/components/sections/Faq.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useState } from 'react';
+import type { FaqSection } from '@/lib/strapi-types';
+
+interface FaqProps {
+  section: FaqSection;
+}
+
+export function Faq({ section }: FaqProps) {
+  const { items } = section;
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+
+  return (
+    <section className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 py-16">
+      <div className="divide-y divide-muted border-t border-b border-muted">
+        {items.map((item, i) => (
+          <div key={item.id}>
+            <button
+              onClick={() => setOpenIndex(openIndex === i ? null : i)}
+              className="w-full flex items-center justify-between py-5 text-left group"
+            >
+              <span className="font-sans font-medium text-foreground group-hover:text-accent transition-colors">
+                {item.question}
+              </span>
+              <span className="font-mono text-foreground/60 ml-4 flex-shrink-0 transition-transform duration-200"
+                style={{ transform: openIndex === i ? 'rotate(45deg)' : 'none' }}>
+                +
+              </span>
+            </button>
+            {openIndex === i && (
+              <div className="pb-5">
+                <p className="font-sans text-foreground/70 leading-relaxed">{item.answer}</p>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/HeroBanner.tsx
+++ b/src/components/sections/HeroBanner.tsx
@@ -1,0 +1,48 @@
+import Image from 'next/image';
+import type { HeroBannerSection } from '@/lib/strapi-types';
+import { Button } from '@/components/ui/Button';
+
+interface HeroBannerProps {
+  section: HeroBannerSection;
+}
+
+export function HeroBanner({ section }: HeroBannerProps) {
+  const { headline, subheadline, cta_text, cta_url, background_image } = section;
+  const strapiUrl = process.env.NEXT_PUBLIC_STRAPI_URL ?? '';
+
+  return (
+    <section className="relative w-full min-h-[70vh] flex items-center bg-background overflow-hidden">
+      {background_image && (
+        <Image
+          src={`${strapiUrl}${background_image.url}`}
+          alt={background_image.alternativeText ?? ''}
+          fill
+          className="object-cover object-center opacity-20"
+          priority
+        />
+      )}
+
+      <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-24">
+        <h1 className="font-serif text-5xl md:text-7xl text-foreground leading-tight max-w-3xl">
+          {headline}
+        </h1>
+
+        {subheadline && (
+          <p className="mt-6 font-sans text-lg text-foreground/70 max-w-xl leading-relaxed">
+            {subheadline}
+          </p>
+        )}
+
+        {cta_text && cta_url && (
+          <div className="mt-10">
+            <a href={cta_url}>
+              <Button variant="primary" size="lg">
+                {cta_text}
+              </Button>
+            </a>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/ImageGallery.tsx
+++ b/src/components/sections/ImageGallery.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import Image from 'next/image';
+import { useState } from 'react';
+import type { ImageGallerySection } from '@/lib/strapi-types';
+
+interface ImageGalleryProps {
+  section: ImageGallerySection;
+}
+
+export function ImageGallery({ section }: ImageGalleryProps) {
+  const { images } = section;
+  const strapiUrl = process.env.NEXT_PUBLIC_STRAPI_URL ?? '';
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+
+  return (
+    <section className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+        {images.map((image, i) => (
+          <button
+            key={image.id}
+            onClick={() => setActiveIndex(i)}
+            className="relative aspect-square overflow-hidden hover:opacity-90 transition-opacity"
+          >
+            <Image
+              src={`${strapiUrl}${image.url}`}
+              alt={image.alternativeText ?? ''}
+              fill
+              className="object-cover"
+            />
+          </button>
+        ))}
+      </div>
+
+      {/* Lightbox */}
+      {activeIndex !== null && (
+        <div
+          className="fixed inset-0 bg-foreground/90 z-50 flex items-center justify-center p-4"
+          onClick={() => setActiveIndex(null)}
+        >
+          <div className="relative max-w-4xl w-full aspect-[4/3]">
+            <Image
+              src={`${strapiUrl}${images[activeIndex].url}`}
+              alt={images[activeIndex].alternativeText ?? ''}
+              fill
+              className="object-contain"
+            />
+          </div>
+          <button
+            className="absolute top-4 right-4 font-mono text-background text-xl hover:text-muted transition-colors"
+            onClick={() => setActiveIndex(null)}
+          >
+            ✕
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/sections/ImageText.tsx
+++ b/src/components/sections/ImageText.tsx
@@ -1,0 +1,33 @@
+import Image from 'next/image';
+import type { ImageTextSection } from '@/lib/strapi-types';
+import { Button } from '@/components/ui/Button';
+
+interface ImageTextProps {
+  section: ImageTextSection;
+}
+
+export function ImageText({ section }: ImageTextProps) {
+  const { image, headline, body, image_position } = section;
+  const strapiUrl = process.env.NEXT_PUBLIC_STRAPI_URL ?? '';
+  const isLeft = image_position === 'left';
+
+  return (
+    <section className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+      <div className={`flex flex-col gap-12 ${isLeft ? 'md:flex-row' : 'md:flex-row-reverse'} items-center`}>
+        <div className="w-full md:w-1/2 relative aspect-[4/3] overflow-hidden">
+          <Image
+            src={`${strapiUrl}${image.url}`}
+            alt={image.alternativeText ?? ''}
+            fill
+            className="object-cover"
+          />
+        </div>
+
+        <div className="w-full md:w-1/2">
+          <h2 className="font-serif text-4xl text-foreground mb-6 leading-tight">{headline}</h2>
+          <p className="font-sans text-foreground/70 leading-relaxed mb-8">{body}</p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/ProductPlacement.tsx
+++ b/src/components/sections/ProductPlacement.tsx
@@ -1,0 +1,15 @@
+import type { ProductPlacementSection } from '@/lib/strapi-types';
+import { ProductGrid } from '@/components/product/ProductGrid';
+
+interface ProductPlacementProps {
+  section: ProductPlacementSection;
+}
+
+export function ProductPlacement({ section }: ProductPlacementProps) {
+  return (
+    <section className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+      <h2 className="font-serif text-3xl text-foreground mb-10">{section.title}</h2>
+      <ProductGrid products={section.products} />
+    </section>
+  );
+}

--- a/src/components/sections/SectionRenderer.tsx
+++ b/src/components/sections/SectionRenderer.tsx
@@ -1,0 +1,42 @@
+import type { LandingPageSection } from '@/lib/strapi-types';
+import { HeroBanner } from './HeroBanner';
+import { ProductPlacement } from './ProductPlacement';
+import { CtaBlock } from './CtaBlock';
+import { TextBlock } from './TextBlock';
+import { ImageText } from './ImageText';
+import { ImageGallery } from './ImageGallery';
+import { Testimonials } from './Testimonials';
+import { Faq } from './Faq';
+
+interface SectionRendererProps {
+  sections: LandingPageSection[];
+}
+
+export function SectionRenderer({ sections }: SectionRendererProps) {
+  return (
+    <>
+      {sections.map((section, i) => {
+        switch (section.__component) {
+          case 'sections.hero-banner':
+            return <HeroBanner key={i} section={section} />;
+          case 'sections.product-placement':
+            return <ProductPlacement key={i} section={section} />;
+          case 'sections.cta-block':
+            return <CtaBlock key={i} section={section} />;
+          case 'sections.text-block':
+            return <TextBlock key={i} section={section} />;
+          case 'sections.image-text':
+            return <ImageText key={i} section={section} />;
+          case 'sections.image-gallery':
+            return <ImageGallery key={i} section={section} />;
+          case 'sections.testimonials':
+            return <Testimonials key={i} section={section} />;
+          case 'sections.faq':
+            return <Faq key={i} section={section} />;
+          default:
+            return null;
+        }
+      })}
+    </>
+  );
+}

--- a/src/components/sections/Testimonials.tsx
+++ b/src/components/sections/Testimonials.tsx
@@ -1,0 +1,36 @@
+import type { TestimonialsSection } from '@/lib/strapi-types';
+
+interface TestimonialsProps {
+  section: TestimonialsSection;
+}
+
+export function Testimonials({ section }: TestimonialsProps) {
+  const { testimonials } = section;
+
+  return (
+    <section className="bg-muted py-16">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+          {testimonials.map((item) => (
+            <blockquote
+              key={item.id}
+              className="bg-background p-8 border border-muted"
+            >
+              <p className="font-serif text-lg text-foreground leading-relaxed mb-6">
+                &ldquo;{item.quote}&rdquo;
+              </p>
+              <footer>
+                <p className="font-mono text-sm uppercase tracking-wider text-foreground">
+                  {item.author}
+                </p>
+                {item.role && (
+                  <p className="font-sans text-xs text-foreground/60 mt-0.5">{item.role}</p>
+                )}
+              </footer>
+            </blockquote>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/TextBlock.tsx
+++ b/src/components/sections/TextBlock.tsx
@@ -1,0 +1,14 @@
+import type { TextBlockSection } from '@/lib/strapi-types';
+import { RichText } from '@/components/ui/RichText';
+
+interface TextBlockProps {
+  section: TextBlockSection;
+}
+
+export function TextBlock({ section }: TextBlockProps) {
+  return (
+    <section className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 py-16">
+      <RichText content={section.content} />
+    </section>
+  );
+}

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,0 +1,28 @@
+type Variant = 'default' | 'success' | 'warning' | 'error';
+
+interface BadgeProps {
+  variant?: Variant;
+  children: React.ReactNode;
+  className?: string;
+}
+
+const variantClasses: Record<Variant, string> = {
+  default: 'bg-foreground text-background',
+  success: 'bg-green-700 text-white',
+  warning: 'bg-accent text-white',
+  error: 'bg-red-700 text-white',
+};
+
+export function Badge({ variant = 'default', children, className = '' }: BadgeProps) {
+  return (
+    <span
+      className={[
+        'inline-block font-mono text-xs uppercase tracking-wider px-2 py-0.5',
+        variantClasses[variant],
+        className,
+      ].join(' ')}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,64 @@
+import { type ButtonHTMLAttributes, forwardRef } from 'react';
+
+type Variant = 'primary' | 'secondary' | 'ghost';
+type Size = 'sm' | 'md' | 'lg';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: Variant;
+  size?: Size;
+  loading?: boolean;
+  asChild?: boolean;
+}
+
+const variantClasses: Record<Variant, string> = {
+  primary:
+    'bg-accent text-white hover:bg-accent/90 border border-accent',
+  secondary:
+    'bg-transparent text-foreground border border-foreground hover:bg-foreground hover:text-background',
+  ghost:
+    'bg-transparent text-foreground border border-transparent hover:bg-muted',
+};
+
+const sizeClasses: Record<Size, string> = {
+  sm: 'px-3 py-1.5 text-xs',
+  md: 'px-5 py-2.5 text-sm',
+  lg: 'px-8 py-3.5 text-base',
+};
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    {
+      variant = 'primary',
+      size = 'md',
+      loading = false,
+      disabled,
+      className = '',
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <button
+        ref={ref}
+        disabled={disabled || loading}
+        className={[
+          'inline-flex items-center justify-center gap-2',
+          'font-mono uppercase tracking-wider transition-colors',
+          'disabled:opacity-50 disabled:cursor-not-allowed',
+          variantClasses[variant],
+          sizeClasses[size],
+          className,
+        ].join(' ')}
+        {...props}
+      >
+        {loading && (
+          <span className="inline-block w-3.5 h-3.5 border-2 border-current border-t-transparent rounded-full animate-spin" />
+        )}
+        {children}
+      </button>
+    );
+  }
+);
+
+Button.displayName = 'Button';

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,0 +1,19 @@
+interface CardProps {
+  children: React.ReactNode;
+  className?: string;
+  hover?: boolean;
+}
+
+export function Card({ children, className = '', hover = false }: CardProps) {
+  return (
+    <div
+      className={[
+        'bg-background border border-muted',
+        hover ? 'transition-shadow hover:shadow-md cursor-pointer' : '',
+        className,
+      ].join(' ')}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/ui/Konfetti.tsx
+++ b/src/components/ui/Konfetti.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useEffect } from 'react';
+import type { Options } from 'canvas-confetti';
+
+// Dynamic import to avoid SSR issues
+async function fireKonfetti() {
+  const confetti = (await import('canvas-confetti')).default;
+
+  const options: Options = {
+    particleCount: 120,
+    spread: 80,
+    origin: { y: 0.6 },
+    colors: [
+      '#D4622A', // FORMA accent (Terrakotta)
+      '#FAFAF9', // FORMA background (Creme)
+      '#1A1A18', // FORMA foreground
+      '#E8E6E1', // FORMA muted
+    ],
+  };
+
+  confetti(options);
+}
+
+interface KonfettiProps {
+  /** Delay in ms before firing (default: 300) */
+  delay?: number;
+}
+
+export function Konfetti({ delay = 300 }: KonfettiProps) {
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      fireKonfetti();
+    }, delay);
+
+    return () => clearTimeout(timer);
+  }, [delay]);
+
+  return null;
+}

--- a/src/components/ui/RichText.tsx
+++ b/src/components/ui/RichText.tsx
@@ -1,0 +1,39 @@
+interface RichTextProps {
+  content: string;
+  className?: string;
+}
+
+export function RichText({ content, className = '' }: RichTextProps) {
+  return (
+    <div
+      className={[
+        'prose prose-sm max-w-none',
+        // Headings
+        '[&_h1]:font-serif [&_h1]:text-4xl [&_h1]:text-foreground [&_h1]:mb-4',
+        '[&_h2]:font-serif [&_h2]:text-3xl [&_h2]:text-foreground [&_h2]:mb-3',
+        '[&_h3]:font-serif [&_h3]:text-2xl [&_h3]:text-foreground [&_h3]:mb-3',
+        '[&_h4]:font-sans [&_h4]:text-xl [&_h4]:font-semibold [&_h4]:text-foreground [&_h4]:mb-2',
+        '[&_h5]:font-sans [&_h5]:text-lg [&_h5]:font-semibold [&_h5]:text-foreground [&_h5]:mb-2',
+        '[&_h6]:font-sans [&_h6]:text-base [&_h6]:font-semibold [&_h6]:text-foreground [&_h6]:mb-2',
+        // Body
+        '[&_p]:font-sans [&_p]:text-foreground [&_p]:leading-relaxed [&_p]:mb-4',
+        // Lists
+        '[&_ul]:list-disc [&_ul]:pl-6 [&_ul]:mb-4',
+        '[&_ol]:list-decimal [&_ol]:pl-6 [&_ol]:mb-4',
+        '[&_li]:font-sans [&_li]:text-foreground [&_li]:mb-1',
+        // Blockquote
+        '[&_blockquote]:border-l-4 [&_blockquote]:border-accent [&_blockquote]:pl-4 [&_blockquote]:italic [&_blockquote]:text-foreground/70 [&_blockquote]:mb-4',
+        // Code
+        '[&_code]:font-mono [&_code]:text-sm [&_code]:bg-muted [&_code]:px-1.5 [&_code]:py-0.5',
+        '[&_pre]:font-mono [&_pre]:text-sm [&_pre]:bg-muted [&_pre]:p-4 [&_pre]:mb-4 [&_pre]:overflow-x-auto',
+        // Links
+        '[&_a]:text-accent [&_a]:underline [&_a]:hover:no-underline',
+        // Strong / em
+        '[&_strong]:font-semibold',
+        '[&_em]:italic',
+        className,
+      ].join(' ')}
+      dangerouslySetInnerHTML={{ __html: content }}
+    />
+  );
+}

--- a/src/components/ui/SeoHead.tsx
+++ b/src/components/ui/SeoHead.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from 'next';
+import type { SeoMetadata } from '@/lib/strapi-types';
+
+interface SeoHeadOptions {
+  seo: SeoMetadata | null;
+  fallbackTitle: string;
+  fallbackDescription?: string;
+  siteUrl?: string;
+}
+
+/**
+ * Converts a Strapi SeoMetadata object into a Next.js Metadata object.
+ * Use in generateMetadata() functions of page components.
+ */
+export function buildMetadata({
+  seo,
+  fallbackTitle,
+  fallbackDescription = '',
+  siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? '',
+}: SeoHeadOptions): Metadata {
+  const title = seo?.meta_title ?? fallbackTitle;
+  const description = seo?.meta_description ?? fallbackDescription;
+  const canonical = seo?.canonical_url
+    ? `${siteUrl}${seo.canonical_url}`
+    : undefined;
+
+  const ogImageUrl = seo?.og_image
+    ? `${process.env.NEXT_PUBLIC_STRAPI_URL ?? ''}${seo.og_image.url}`
+    : undefined;
+
+  return {
+    title,
+    description,
+    robots: seo?.no_index ? { index: false, follow: false } : undefined,
+    alternates: canonical ? { canonical } : undefined,
+    openGraph: {
+      title,
+      description,
+      images: ogImageUrl ? [{ url: ogImageUrl }] : undefined,
+    },
+  };
+}


### PR DESCRIPTION
## Beschreibung

Closes #8

Vollständige UI Component Library für den FORMA Demo-Shop – 24 Komponenten in 5 Kategorien.

## Komponenten

### UI Primitives (`src/components/ui/`)
- **Button** – Varianten: primary/secondary/ghost, Sizes: sm/md/lg, loading-State
- **Badge** – default/success/warning/error
- **Card** – Generic Wrapper mit optionalem hover:shadow
- **RichText** – Rendert Strapi Richtext als HTML mit FORMA-Styles
- **SeoHead** – `buildMetadata()` Helper für Next.js `generateMetadata()`
- **Konfetti** – Canvas-Confetti in FORMA-Farben (Terrakotta + Creme), lazy-loaded

### Sections (`src/components/sections/`)
- **HeroBanner** – Fullwidth Hero mit optionalem Hintergrundbild
- **ProductPlacement** – Produktraster mit Titel
- **CtaBlock** – Zentrierter CTA auf dunklem Hintergrund
- **TextBlock** – Freier Richtext-Block
- **ImageText** – Split-Layout Bild links/rechts
- **ImageGallery** – CSS Grid + Lightbox (Click-to-Expand)
- **Testimonials** – Zitat-Grid
- **Faq** – Accordion
- **SectionRenderer** – Switch für alle 8 Section-Types via `__component`

### Produkte (`src/components/product/`)
- **ProductCard** – Bild, Name, Preis, Badges (Neu/Sale/Ausverkauft)
- **ProductGrid** – Responsive 1→2→3/4 Col Grid
- **ProductGallery** – Hauptbild + Thumbnails
- **VariantSelector** – Option-Buttons, ausverkaufte Varianten durchgestrichen
- **PriceDisplay** – Preis + compare_at_price, Intl.NumberFormat

### Blog (`src/components/blog/`)
- **BlogCard** – Cover, Titel, Excerpt, Autor, Lesedauer, Datum
- **BlogGrid** – Responsive 1→2→3 Col Grid

### Checkout (`src/components/checkout/`)
- **CheckoutForm** – react-hook-form + native Validation, Loading-State, Success mit Konfetti
- **OrderSummary** – Produktname, Variante, Preis, Gesamt

## Checkliste

- [x] TypeScript – alle Komponenten korrekt typisiert, Strapi-Types aus `#6` verwendet
- [x] Kein `@hookform/resolvers` – native RHF-Validation (nicht in dependencies)
- [x] FORMA-Farben + Fonts konsistent in allen Komponenten
- [x] Responsive: Mobile-first, 375px → 1440px
- [x] Server/Client-Boundary korrekt markiert (`'use client'` nur wo nötig)
- [x] Keine Secrets committed