### PR TITLE
feat: checkout flow with n8n lead capture and cart indicator

### DIFF
--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+export const dynamic = 'force-dynamic';
+
+const schema = z.object({
+  customerName: z.string().min(2),
+  customerEmail: z.string().email(),
+  company: z.string().optional(),
+  productName: z.string(),
+  totalAmount: z.number().positive(),
+});
+
+export async function POST(request: NextRequest) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ message: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { message: 'Validation error', errors: parsed.error.flatten() },
+      { status: 422 }
+    );
+  }
+
+  const { customerName, customerEmail, company, productName, totalAmount } = parsed.data;
+
+  const webhookUrl = process.env.N8N_WEBHOOK_URL;
+  if (webhookUrl) {
+    try {
+      const res = await fetch(webhookUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ customerName, customerEmail, company, productName, totalAmount }),
+      });
+      if (!res.ok) {
+        console.error(`[checkout] n8n webhook failed: ${res.status} ${res.statusText}`);
+      }
+    } catch (err) {
+      // Graceful degradation – Danke-Seite trotzdem zeigen
+      console.error('[checkout] n8n webhook error (non-blocking):', err);
+    }
+  } else {
+    console.warn('[checkout] N8N_WEBHOOK_URL not configured – skipping webhook');
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/components/checkout/CheckoutForm.tsx
+++ b/src/components/checkout/CheckoutForm.tsx
@@ -2,9 +2,10 @@
 
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/Button';
-import { Konfetti } from '@/components/ui/Konfetti';
+import { useCartStore } from '@/lib/cart-store';
 
 interface FormData {
   firstName: string;
@@ -26,13 +27,13 @@ export function CheckoutForm({
   price,
 }: CheckoutFormProps) {
   const t = useTranslations('checkout');
-  const [success, setSuccess] = useState(false);
+  const router = useRouter();
+  const clearCart = useCartStore((s) => s.clearCart);
   const [apiError, setApiError] = useState<string | null>(null);
 
   const {
     register,
     handleSubmit,
-    getValues,
     formState: { errors, isSubmitting },
   } = useForm<FormData>();
 
@@ -42,7 +43,13 @@ export function CheckoutForm({
       const res = await fetch('/api/checkout', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ...data, productId, variantId, price }),
+        body: JSON.stringify({
+          customerName: data.firstName,
+          customerEmail: data.email,
+          company: data.company,
+          productName,
+          totalAmount: price,
+        }),
       });
 
       if (!res.ok) {
@@ -51,22 +58,11 @@ export function CheckoutForm({
         return;
       }
 
-      setSuccess(true);
+      clearCart();
+      router.push('/danke');
     } catch {
       setApiError('Netzwerkfehler – bitte versuche es erneut');
     }
-  }
-
-  if (success) {
-    return (
-      <div className="py-12 text-center">
-        <Konfetti />
-        <h2 className="font-serif text-3xl text-foreground mb-4">{t('success.title')}</h2>
-        <p className="font-sans text-foreground/70">
-          {t('success.message', { email: getValues('email') })}
-        </p>
-      </div>
-    );
   }
 
   return (

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -3,9 +3,11 @@
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import LocaleSwitcher from './LocaleSwitcher';
+import { useCartStore } from '@/lib/cart-store';
 
 export default function Header() {
   const t = useTranslations('navigation');
+  const itemCount = useCartStore((s) => s.totalItems());
 
   return (
     <header className="border-b border-muted bg-background">
@@ -41,13 +43,18 @@ export default function Header() {
 
           <div className="flex items-center gap-4">
             <LocaleSwitcher />
-            {/* Cart-Indikator wird in Issue #10 implementiert */}
-            <button
+            <Link
+              href="/checkout"
               aria-label={t('cart')}
-              className="font-mono text-sm uppercase tracking-wider text-foreground hover:text-accent transition-colors"
+              className="relative font-mono text-sm uppercase tracking-wider text-foreground hover:text-accent transition-colors"
             >
-              {t('cart')} (0)
-            </button>
+              {t('cart')}
+              {itemCount > 0 && (
+                <span className="ml-1 inline-flex items-center justify-center w-5 h-5 bg-accent text-white text-xs font-bold rounded-full">
+                  {itemCount}
+                </span>
+              )}
+            </Link>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Beschreibung

Closes #10

Vollständiger Checkout-Funnel als Lead-Capture via n8n.

## Änderungen

### `src/app/api/checkout/route.ts` (NEU)
- `POST /api/checkout` – Server-only Route Handler
- zod-Validierung: `customerName`, `customerEmail`, `company`, `productName`, `totalAmount`
- POST an `N8N_WEBHOOK_URL` (graceful degradation wenn nicht erreichbar)
- `force-dynamic`, `N8N_WEBHOOK_URL` nie im Browser-Bundle

### `src/components/layout/Header.tsx`
- Cart-Indikator: Link zu `/checkout` mit Terrakotta-Badge wenn `itemCount > 0`
- Verwendet `useCartStore` aus `src/lib/cart-store.ts`

### `src/components/checkout/CheckoutForm.tsx`
- POST an `/api/checkout` mit korrektem Payload-Mapping
- Nach Erfolg: `clearCart()` + `router.push('/danke')`

## Flow

```
Produktdetailseite [Jetzt anfragen]
  → addItem() → Cart-Store (Zustand, persisted)
  → router.push('/checkout')
    → CheckoutForm: POST /api/checkout
      → n8n Webhook → Twenty CRM + Bestätigungs-E-Mail
    → clearCart() + router.push('/danke')
      → Konfetti 🎉
```

## Checkliste

- [x] `N8N_WEBHOOK_URL` Server-only (kein NEXT_PUBLIC_)
- [x] Graceful degradation: Danke-Seite auch ohne n8n
- [x] Cart-Badge sichtbar wenn Items vorhanden
- [x] Keine Secrets committed