### PR TITLE
feat: SEO metadata, sitemap, robots.txt and OpenGraph tags

### DIFF
--- a/public/images/og-default.svg
+++ b/public/images/og-default.svg
@@ -1,0 +1,33 @@
+<svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background -->
+  <rect width="1200" height="630" fill="#FAFAF9"/>
+
+  <!-- Accent line -->
+  <rect x="80" y="80" width="6" height="120" fill="#D4622A"/>
+
+  <!-- FORMA wordmark -->
+  <text
+    x="110"
+    y="175"
+    font-family="Georgia, serif"
+    font-size="96"
+    font-weight="400"
+    fill="#1A1A18"
+    letter-spacing="-2"
+  >FORMA</text>
+
+  <!-- Tagline -->
+  <text
+    x="112"
+    y="240"
+    font-family="monospace"
+    font-size="22"
+    font-weight="400"
+    fill="#1A1A18"
+    opacity="0.5"
+    letter-spacing="4"
+  >WERKZEUGE, DIE WIRKEN.</text>
+
+  <!-- Bottom accent bar -->
+  <rect x="0" y="590" width="1200" height="40" fill="#D4622A"/>
+</svg>

--- a/src/app/[locale]/checkout/page.tsx
+++ b/src/app/[locale]/checkout/page.tsx
@@ -5,6 +5,7 @@ export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
   title: 'Checkout – FORMA',
+  robots: { index: false, follow: false },
 };
 
 export default function CheckoutPage() {

--- a/src/app/[locale]/danke/page.tsx
+++ b/src/app/[locale]/danke/page.tsx
@@ -5,6 +5,7 @@ import { Konfetti } from '@/components/ui/Konfetti';
 
 export const metadata: Metadata = {
   title: 'Vielen Dank! – FORMA',
+  robots: { index: false, follow: false },
 };
 
 export default function DankePage() {

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -27,9 +27,23 @@ const jetbrainsMono = JetBrains_Mono({
   display: 'swap',
 });
 
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? '';
+
 export const metadata: Metadata = {
-  title: 'FORMA – Werkzeuge, die wirken.',
-  description: 'Hochwertige digitale Werkzeuge für Ihren Alltag.',
+  title: {
+    default: 'FORMA – Werkzeuge, die wirken.',
+    template: '%s – FORMA',
+  },
+  description: 'Kuratierte digitale Produkte für moderne Teams.',
+  metadataBase: new URL(siteUrl || 'https://example.com'),
+  openGraph: {
+    siteName: 'FORMA',
+    type: 'website',
+    images: [{ url: '/images/og-default.svg', width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+  },
 };
 
 type Props = {

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from 'next';
+
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://example.com';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: [
+          '/api/',
+          '/*/checkout',
+          '/*/danke',
+        ],
+      },
+    ],
+    sitemap: `${siteUrl}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,84 @@
+import type { MetadataRoute } from 'next';
+import { getBlogPosts, getCategories, getProducts } from '@/lib/strapi';
+
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://example.com';
+const locales = ['de', 'en'];
+
+function alternates(path: string) {
+  return Object.fromEntries(locales.map((loc) => [loc, `${siteUrl}/${loc}${path}`]));
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const entries: MetadataRoute.Sitemap = [];
+
+  // ── Static pages ──────────────────────────────────────────────────────────
+
+  for (const locale of locales) {
+    entries.push(
+      { url: `${siteUrl}/${locale}`, lastModified: new Date(), changeFrequency: 'daily', priority: 1.0 },
+      { url: `${siteUrl}/${locale}/shop`, lastModified: new Date(), changeFrequency: 'weekly', priority: 0.9 },
+      { url: `${siteUrl}/${locale}/blog`, lastModified: new Date(), changeFrequency: 'daily', priority: 0.8 },
+    );
+  }
+
+  // ── Dynamic: Categories ───────────────────────────────────────────────────
+
+  try {
+    const catsRes = await getCategories({ fields: ['slug', 'updatedAt'], pagination: { pageSize: 100 } });
+    for (const cat of catsRes.data) {
+      for (const locale of locales) {
+        entries.push({
+          url: `${siteUrl}/${locale}/shop/${cat.slug}`,
+          lastModified: new Date(cat.updatedAt),
+          changeFrequency: 'weekly',
+          priority: 0.8,
+          alternates: { languages: alternates(`/shop/${cat.slug}`) },
+        });
+      }
+    }
+  } catch {}
+
+  // ── Dynamic: Products ─────────────────────────────────────────────────────
+
+  try {
+    const prodsRes = await getProducts({
+      fields: ['slug', 'updatedAt'],
+      populate: ['categories'],
+      pagination: { pageSize: 500 },
+    });
+    for (const prod of prodsRes.data) {
+      const categorySlug = prod.categories?.[0]?.slug ?? 'uncategorized';
+      for (const locale of locales) {
+        entries.push({
+          url: `${siteUrl}/${locale}/shop/${categorySlug}/${prod.slug}`,
+          lastModified: new Date(prod.updatedAt),
+          changeFrequency: 'weekly',
+          priority: 0.8,
+          alternates: { languages: alternates(`/shop/${categorySlug}/${prod.slug}`) },
+        });
+      }
+    }
+  } catch {}
+
+  // ── Dynamic: Blog Posts ───────────────────────────────────────────────────
+
+  try {
+    const postsRes = await getBlogPosts({
+      fields: ['slug', 'updatedAt'],
+      pagination: { pageSize: 200 },
+    });
+    for (const post of postsRes.data) {
+      for (const locale of locales) {
+        entries.push({
+          url: `${siteUrl}/${locale}/blog/${post.slug}`,
+          lastModified: new Date(post.updatedAt),
+          changeFrequency: 'monthly',
+          priority: 0.7,
+          alternates: { languages: alternates(`/blog/${post.slug}`) },
+        });
+      }
+    }
+  } catch {}
+
+  return entries;
+}


### PR DESCRIPTION
## Beschreibung

Closes #11

Vollständige SEO-Optimierung: Sitemap, robots.txt, OG-Default-Image, noIndex für Transaktionsseiten und globale Metadata-Basis.

## Änderungen

### `src/app/sitemap.ts` (NEU)
- Next.js 15 `MetadataRoute.Sitemap` – dynamisch aus Strapi
- Statisch: Homepage, `/shop`, `/blog` für beide Locales (de + en)
- Dynamisch: alle Kategorien, Produkte (mit Kategorie-Pfad), Blog-Posts
- `lastModified` aus Strapi `updatedAt`, `alternates.languages` pro Locale
- Graceful Degradation wenn Strapi nicht erreichbar

### `src/app/robots.ts` (NEU)
- `Allow: /` für alle User-Agents
- `Disallow: /api/`, `/*/checkout`, `/*/danke`
- `Sitemap: ${NEXT_PUBLIC_SITE_URL}/sitemap.xml`

### `public/images/og-default.svg` (NEU)
- 1200×630px SVG im FORMA-Brand
- Hintergrund `#FAFAF9`, Wordmark `#1A1A18`, Accent-Linie `#D4622A`
- „FORMA" + Tagline „WERKZEUGE, DIE WIRKEN."

### `src/app/[locale]/layout.tsx`
- `metadata.title.template: '%s – FORMA'`
- `metadataBase` aus `NEXT_PUBLIC_SITE_URL`
- Globale OG-Tags mit `/images/og-default.svg` als Fallback
- `twitter.card: 'summary_large_image'`

### Checkout & Danke Seiten
- `robots: { index: false, follow: false }` auf beiden Seiten

## Checkliste

- [x] `GET /sitemap.xml` – valides XML mit allen Produkten/Kategorien/Blog-Posts
- [x] `GET /robots.txt` – korrekte Direktiven
- [x] Checkout + Danke: `<meta name="robots" content="noindex, nofollow">`
- [x] OG-Default-Image 1200×630px im FORMA-Brand
- [x] Keine Secrets committed